### PR TITLE
Fixing typo in the daily view of the menu

### DIFF
--- a/views/daily.erb
+++ b/views/daily.erb
@@ -26,7 +26,7 @@
                 <table class="pure-table pure-table-bordered">
                     <thead class="is-center">
                         <% @meals.each do |meal| %>
-                            <% period = (meal.period == Period.both) ? 'LAUNCH & DINNER' : meal.period %>
+                            <% period = (meal.period == Period.both) ? 'LUNCH & DINNER' : meal.period %>
                             <th><%= period %></th>
                         <% end %>
                     </thead>


### PR DESCRIPTION
There is a typo in the main site when visualizing the daily menu. This PR fixes this simple error.