### PR TITLE
Insert requires in bootstrap file instead of app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'sinatra/activerecord/rake'
 require 'sinatra/asset_pipeline/task'
-require './app'
+require './bootstrap'
 
 Sinatra::AssetPipeline::Task.define! Sinatra::Application
 

--- a/app.rb
+++ b/app.rb
@@ -1,27 +1,3 @@
-# We could use Bundler.require, but I guess that explicit requires fits better our application
-# http://myronmars.to/n/dev-blog/2012/12/5-reasons-to-avoid-bundler-require
-
-require 'sinatra'
-require 'sinatra/respond_with'
-require 'sinatra/activerecord'
-require 'sinatra/asset_pipeline'
-require 'sinatra/i18n'
-require 'sinatra/capture'
-require 'sinatra/flash'
-
-require 'rails-assets-pure'
-require 'rails-assets-css-hamburgers'
-require 'font-awesome-sass'
-
-require 'dotenv'
-
-Dir.glob('./models/*.rb') { |file| require file }
-Dir.glob('./jobs/*.rb') { |file| require file }
-Dir.glob('./controllers/*.rb') { |file| require file }
-
-require './views/view_helper.rb'
-require './parsers/parsers'
-
 configure do
   set :root, File.dirname(__FILE__)
   set :is_production, (ENV['RACK_ENV'] == 'production')

--- a/bootstrap.rb
+++ b/bootstrap.rb
@@ -1,0 +1,25 @@
+# We could use Bundler.require, but I guess that explicit requires fits better our application
+# http://myronmars.to/n/dev-blog/2012/12/5-reasons-to-avoid-bundler-require
+
+require 'sinatra'
+require 'sinatra/respond_with'
+require 'sinatra/activerecord'
+require 'sinatra/asset_pipeline'
+require 'sinatra/i18n'
+require 'sinatra/capture'
+require 'sinatra/flash'
+
+require 'rails-assets-pure'
+require 'rails-assets-css-hamburgers'
+require 'font-awesome-sass'
+
+require 'dotenv'
+
+Dir.glob('./models/*.rb') { |file| require file }
+Dir.glob('./jobs/*.rb') { |file| require file }
+Dir.glob('./controllers/*.rb') { |file| require file }
+
+require './views/view_helper.rb'
+require './parsers/parsers'
+
+require './app.rb'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ require 'capybara/rspec'
 
 ENV['RACK_ENV'] = 'test'
 
-require File.expand_path '../../app.rb', __FILE__
+require File.expand_path '../../bootstrap.rb', __FILE__
 
 module RSpecMixin
   include Rack::Test::Methods


### PR DESCRIPTION
app.rb file was requiring all files and also configuring sinatra.

We should split those requires into a file that only has the responsibility of requiring the components. 